### PR TITLE
fix: navbar was overflowing if not on mobile

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -379,7 +379,7 @@ export function NavBar() {
           width="100%"
           position={{ base: 'fixed', md: 'relative' }}
           zIndex="overlay"
-          top="13px"
+          top={{ base: '13px', md: '0px' }}
           as="nav"
           pl={{ xxl: '14vw', xl: '80px', md: '5vw', base: '0px' }}
           pr={{ xxl: '14vw', xl: '80px', md: '5vw', base: '0px' }}


### PR DESCRIPTION
Previous:
![image](https://user-images.githubusercontent.com/19688421/130333365-bf052750-2872-48cc-8a21-222f763caf61.png)

Now:
![image](https://user-images.githubusercontent.com/19688421/130333368-3abb6c96-b062-45d7-b3bb-a4a74e25511b.png)
